### PR TITLE
ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
         run: npm ci
 
       - name: Setup macOS Notarization env
-        if: startsWith(matrix.os, 'macos')
+        if: contains(matrix.os, 'mac')
         run: |
           rm -fr ~/private_keys && mkdir ~/private_keys
           echo $APPLE_AUTH_PRIVATE_KEY | base64 -D > ~/private_keys/AuthKey_${APPLE_API_KEY}.p8

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,12 @@ jobs:
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.OS }}-node-
-      
+
+      - name: Workaround for GH action env(Android build SDK31)
+        run: |
+          SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+          echo y | $SDKMANAGER --uninstall "build-tools;31.0.0"
+
       - name: Install Dependencies
         run: npm install -g cordova@10 && npm ci
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [self_mac_11.0, ubuntu-latest, windows-latest]
+        os: [self_mac_11.0, ubuntu-18.04, windows-latest]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
+ [workaround](https://github.com/actions/virtual-environments/issues/3757#issuecomment-883646793) for android build tools
+ make native modules work on older Ubuntu versions, tested on 16.04