### PR TITLE
Fix delegation error message

### DIFF
--- a/src/i18n/en-us/index.ts
+++ b/src/i18n/en-us/index.ts
@@ -179,6 +179,7 @@ export default {
         msg_invalid_request: 'Invalid request',
         msg_fetch_request_failed: 'Unable to fetch request content',
         msg_request_hash_mismatch: 'CAUTION: the request content is corrupted or tampered',
+        msg_fee_delegation: 'Fee will be paid by dApp',
 
         // sign success
         title_success: 'Success',

--- a/src/pages/Sign/GasFeeBar.vue
+++ b/src/pages/Sign/GasFeeBar.vue
@@ -17,6 +17,7 @@
                 <q-avatar size="1em">
                     <img src="~assets/vtho.svg">
                 </q-avatar>
+                <q-item-label v-if="isDelegation" caption>{{$t('sign.msg_fee_delegation')}}</q-item-label>
             </q-item-label>
         </q-item-section>
         <q-item-section side>
@@ -33,7 +34,8 @@ import AmountLabel from 'src/components/AmountLabel.vue'
 export default Vue.extend({
     components: { AmountLabel },
     props: {
-        fee: String
+        fee: String,
+        isDelegation: Boolean
     }
 })
 </script>

--- a/src/pages/Sign/TxDialog.vue
+++ b/src/pages/Sign/TxDialog.vue
@@ -170,7 +170,7 @@ export default Common.extend({
         async energyWarning(): Promise<Error | null> {
             const est = this.estimation
             const fee = this.fee
-            if (!est || !fee) {
+            if (!est || !fee || (this.req.options.delegator && !this.req.options.delegator.signer)) {
                 return null
             }
             const signer = this.signer

--- a/src/pages/Sign/TxDialog.vue
+++ b/src/pages/Sign/TxDialog.vue
@@ -40,7 +40,7 @@
                         @click="showWarnings()"
                     />
 
-                    <gas-fee-bar :fee="fee">
+                    <gas-fee-bar :fee="fee" :isDelegation="isDelegation">
                         <priority-selector
                             v-model="gasPriceCoef"
                             :calcFee="calcFee"
@@ -138,6 +138,9 @@ export default Common.extend({
             }
             this.energyWarning && ret.push(this.energyWarning)
             return ret
+        },
+        isDelegation(): boolean {
+            return !!this.req.options.delegator
         },
         thor(): Connex.Thor { return this.$svc.bc(this.gid).thor },
         estimation(): EstimateGasResult | null {


### PR DESCRIPTION
This merge request addresses two issues:


1) If fee delegation is configured without explicit definition of a signer address, Sync2 shows an error about insufficient VTHO balance if the sender has not enough VTHO. Not defining the signer and having a delegator configured, it should expect a positive outcome (not negative) and not show the message:  
![Bildschirmfoto 2022-07-28 um 15 28 18](https://user-images.githubusercontent.com/407503/181525198-f5d1f924-5187-417c-9f16-765d674aeaf4.jpg)

---
 
2) The other change is that users are confused if fee delegation is used. It is not obvious that the fee is paid by another party. The second change introduces a message that existed in Sync-Browser: `Fee will be paid by dApp`

The message key is `sign.msg_fee_delegation` and was only configured for `en-us`. The message needs to be adjusted and translated for all other languages as well. I suggest using the same translations Sync-Browser uses.

Here is an example message:  
![Bildschirmfoto 2022-07-28 um 16 02 32](https://user-images.githubusercontent.com/407503/181525990-38838d3b-8bab-4de1-bb5b-46db673fc6bd.jpg)

---

I did not find any tests in the project. If there are tests, I am happy to extend/adjust them.