### PR TITLE
Auto-hide transfer notifications

### DIFF
--- a/src/pages/TransferNotifier.vue
+++ b/src/pages/TransferNotifier.vue
@@ -173,7 +173,7 @@ export default Vue.extend({
                 message,
                 position: 'top-right',
                 html: true,
-                timeout: 15 * 1000,
+                timeout: 5 * 1000,
                 group: false,
                 classes: 'transfer-notify_w100',
                 actions: [{

--- a/src/pages/TransferNotifier.vue
+++ b/src/pages/TransferNotifier.vue
@@ -173,7 +173,7 @@ export default Vue.extend({
                 message,
                 position: 'top-right',
                 html: true,
-                timeout: 0,
+                timeout: 15 * 1000,
                 group: false,
                 classes: 'transfer-notify_w100',
                 actions: [{


### PR DESCRIPTION
Currently transaction notifications are persistent. The application becomes unusable and stacking notifications seem to remove from the user experience instead of adding value because every notification needs to be confirmed manually.

For example using the faucet to get tokens it will stack notifications where each needs to be confirmed or the app needs to be closed between requests:

![image](https://user-images.githubusercontent.com/407503/187623699-66f22854-d3f3-4f44-823e-7672346b62c3.png)


This pull request proposes to set a timeout of 5 seconds to automatically hide transfer notifications. 5 second was chosen because it seems to be a default value of some existing notification libraries. It seems to be long enough to be aware of the transfer and short enough to not start to be annoying.

