### PR TITLE
Add ability to preview decoded function call data

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -94,6 +94,8 @@ module.exports = configure(function (/* ctx */) {
         "QDialog",
         "QInput",
         "QForm",
+        "QTabs",
+        "QTab",
         "QTabPanels",
         "QTabPanel",
         "QToggle",

--- a/src/pages/Sign/InspectClauseDialog.vue
+++ b/src/pages/Sign/InspectClauseDialog.vue
@@ -42,33 +42,47 @@
                 </q-item>
                 <q-item>
                     <q-item-section>
-                        <q-item-label caption>Data</q-item-label>
-                        <q-item-label>
-                            <q-input
-                                v-if="clause.data && clause.data.length > 2"
-                                dense
-                                class="monospace"
-                                type="textarea"
-                                standout
-                                readonly
-                                :value="clause.data"
-                            />
-                            <template v-else>N/A</template>
-                        </q-item-label>
-                    </q-item-section>
-                </q-item>
-                <q-item v-if="decodedData">
-                    <q-item-section>
-                        <q-item-label>
-                            <q-input
-                                dense
-                                class="monospace"
-                                type="textarea"
-                                standout
-                                readonly
-                                :value="decodedData"
-                            />
-                        </q-item-label>
+                        <q-tabs v-model="dataPanel" no-caps>
+                            <q-tab default name="data" label="Data" />
+                            <q-tab name="decoded" label="Decoded" />
+                            <q-tab name="utf-8" label="UTF-8" />
+                        </q-tabs>
+                        <q-tab-panels animated v-model="dataPanel">
+                            <q-tab-panel name="data">
+                                <q-input
+                                    v-if="clause.data && clause.data.length > 2"
+                                    dense
+                                    class="monospace"
+                                    type="textarea"
+                                    standout
+                                    readonly
+                                    :value="clause.data"
+                                />
+                                <template v-else>N/A</template>
+                            </q-tab-panel>
+                            <q-tab-panel name="decoded">
+                                <q-input
+                                    v-if="decodedData"
+                                    dense
+                                    class="monospace"
+                                    type="textarea"
+                                    standout
+                                    readonly
+                                    :value="decodedData"
+                                />
+                                <template v-else>Unable to decode data</template>
+                            </q-tab-panel>
+                            <q-tab-panel name="utf-8">
+                                <q-input
+                                    dense
+                                    class="monospace"
+                                    type="textarea"
+                                    standout
+                                    readonly
+                                    :value="decodedDataString"
+                                />
+                            </q-tab-panel>
+                        </q-tab-panels>
                     </q-item-section>
                 </q-item>
             </q-list>
@@ -77,17 +91,22 @@
 </template>
 <script lang="ts">
 import Vue from 'vue'
-import { QDialog } from 'quasar'
+import { QDialog, QTabs, QTab, QTabPanels, QTabPanel } from 'quasar'
 import AddressLabel from 'src/components/AddressLabel.vue'
 import AmountLabel from 'src/components/AmountLabel.vue'
 import { abi } from 'thor-devkit'
 import axios from 'axios'
 
 export default Vue.extend({
-    components: { AddressLabel, AmountLabel },
+    components: { AddressLabel, AmountLabel, QTabs, QTab, QTabPanels, QTabPanel },
     props: {
         index: Number,
         clause: Object as () => Connex.Vendor.TxMessage[0]
+    },
+    data() {
+        return {
+            dataPanel: 'data' as 'data' | 'decoded' | 'utf-8'
+        }
     },
     methods: {
         // method is REQUIRED by $q.dialog
@@ -120,6 +139,15 @@ export default Vue.extend({
             } catch {}
 
             return null
+        }
+    },
+    computed: {
+        decodedDataString() {
+            if (!this.clause.data || this.clause.data.length <= 2) {
+                return ''
+            }
+
+            return Buffer.from(this.clause.data.slice(10), 'hex').toString('utf-8')
         }
     }
 })

--- a/src/pages/Sign/InspectClauseDialog.vue
+++ b/src/pages/Sign/InspectClauseDialog.vue
@@ -42,7 +42,7 @@
                 </q-item>
                 <q-item>
                     <q-item-section>
-                        <q-tabs v-model="dataPanel" no-caps>
+                        <q-tabs class="text-grey" active-color="primary" align="left" dense v-model="dataPanel" no-caps>
                             <q-tab default name="data" label="Data" />
                             <q-tab name="decoded" label="Decoded" />
                             <q-tab name="utf-8" label="UTF-8" />
@@ -91,14 +91,14 @@
 </template>
 <script lang="ts">
 import Vue from 'vue'
-import { QDialog, QTabs, QTab, QTabPanels, QTabPanel } from 'quasar'
+import { QDialog} from 'quasar'
 import AddressLabel from 'src/components/AddressLabel.vue'
 import AmountLabel from 'src/components/AmountLabel.vue'
 import { abi } from 'thor-devkit'
 import axios from 'axios'
 
 export default Vue.extend({
-    components: { AddressLabel, AmountLabel, QTabs, QTab, QTabPanels, QTabPanel },
+    components: { AddressLabel, AmountLabel },
     props: {
         index: Number,
         clause: Object as () => Connex.Vendor.TxMessage[0]

--- a/src/pages/Sign/InspectClauseDialog.vue
+++ b/src/pages/Sign/InspectClauseDialog.vue
@@ -57,7 +57,20 @@
                         </q-item-label>
                     </q-item-section>
                 </q-item>
-
+                <q-item v-if="decodedData">
+                    <q-item-section>
+                        <q-item-label>
+                            <q-input
+                                dense
+                                class="monospace"
+                                type="textarea"
+                                standout
+                                readonly
+                                :value="decodedData"
+                            />
+                        </q-item-label>
+                    </q-item-section>
+                </q-item>
             </q-list>
         </q-card>
     </q-dialog>
@@ -67,6 +80,9 @@ import Vue from 'vue'
 import { QDialog } from 'quasar'
 import AddressLabel from 'src/components/AddressLabel.vue'
 import AmountLabel from 'src/components/AmountLabel.vue'
+import { abi } from 'thor-devkit'
+import axios from 'axios'
+
 export default Vue.extend({
     components: { AddressLabel, AmountLabel },
     props: {
@@ -78,6 +94,33 @@ export default Vue.extend({
         show() { (this.$refs.dialog as QDialog).show() },
         // method is REQUIRED by $q.dialog
         hide() { (this.$refs.dialog as QDialog).hide() }
+    },
+    asyncComputed: {
+        async decodedData(): Promise<string | null> {
+            if (!this.clause.data || this.clause.data.length <= 2) {
+                return null
+            }
+
+            const signature = this.clause.data.slice(0, 10)
+            const data = this.clause.data.slice(10)
+
+            try {
+                const response = await axios.get(`https://b32.vecha.in/q/${signature}.json`, { transformResponse: data => data, timeout: 3 * 1000 })
+                const abis = JSON.parse(response.data)
+
+                // try to decode each abi, it may fail on signature collision
+                // return first match
+                for (const abiItem of abis) {
+                    try {
+                        const decodedData = abi.decodeParameters(abiItem.inputs, `0x${data}`)
+                        const readableInputs = abiItem.inputs.map((input: abi.Function.Definition, index: number) => `(${input.type}) ${input.name} ${decodedData[input.name || String(index)]}`)
+                        return `${abiItem.name} (\n${readableInputs.map((line: string) => `  ${line}`).join(', \n')}\n)`
+                    } catch {}
+                }
+            } catch {}
+
+            return null
+        }
     }
 })
 </script>


### PR DESCRIPTION
When signing a transaction the data is hex encoded and not understandable from a human perspective. The situation allows to pretend to users something different than what will be signed.

B32 has a registry of many relevant ABI definitions. Using B32 and the clause data the transaction details can be decoded in a more human friendly format.

This pull request is a modification that will:

1. extract function signature from call data
2. lookup the ABI definition from b32
3. if found, try to decode the clause data using the ABI
4. display a decoded version

It is possible that the function name or parameter names are not identical due the same signature existing in multiple registry entries. It will still provide a better experience and help prevent signing of malicious transactions.

The decoded data is shown at the clause inspection below data:

![image](https://user-images.githubusercontent.com/407503/203303227-a0d3969a-ffb2-4846-b968-669aa04d3bb9.png)