### PR TITLE
update cordova-android to 12, set target to android 13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "org.vechain.sync2",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "org.vechain.sync2",
-      "version": "2.0.8",
+      "version": "2.0.10",
       "hasInstallScript": true,
       "dependencies": {
         "electron-context-menu": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.vechain.sync2",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "VeChain Sync2",
   "productName": "Sync2",
   "cordovaId": "org.vechain.sync2",

--- a/src-cordova/config.xml
+++ b/src-cordova/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="200090" id="org.vechain.sync2" ios-CFBundleIdentifier="org.vechain.sync2app" ios-CFBundleVersion="6" version="2.0.9" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="200100" id="org.vechain.sync2" ios-CFBundleIdentifier="org.vechain.sync2app" ios-CFBundleVersion="7" version="2.0.10" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Sync2</name>
     <description>VeChain Sync2</description>
     <author email="dev@cordova.apache.org" href="http://cordova.io">

--- a/src-cordova/package-lock.json
+++ b/src-cordova/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "cordova-android": "^11.0.0",
+        "cordova-android": "^12.0.0",
         "cordova-clipboard": "^1.3.0",
         "cordova-ios": "^6.2.0",
         "cordova-plugin-add-swift-support": "^2.0.2",
@@ -69,6 +69,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -76,21 +85,12 @@
       "dev": true
     },
     "node_modules/android-versions": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.8.1.tgz",
-      "integrity": "sha512-5a0YyylAk6pPM2Ezi0vWaPPNbS6tSNRs+micbgk5NpHEN5YW1ez+T94G5orysfwBEBDMHoxm5GNc5ZDUPgRrhw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.8.2.tgz",
+      "integrity": "sha512-2MT/Y/mR3BLSbR9E3ugwvE/aA4k84XtjG2Iusu4pRKt4FwfpEvIEAHzm7ZBhL3/aTVNdx3PzZ+sAiK+Dbc4r9A==",
       "dev": true,
       "dependencies": {
-        "semver": "^5.7.1"
-      }
-    },
-    "node_modules/android-versions/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
+        "semver": "^7.5.2"
       }
     },
     "node_modules/ansi": {
@@ -124,10 +124,24 @@
       "dev": true
     },
     "node_modules/base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/big-integer": {
       "version": "1.6.48",
@@ -188,31 +202,92 @@
       "dev": true
     },
     "node_modules/cordova-android": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-11.0.0.tgz",
-      "integrity": "sha512-ZhvSF5BYY8gmrAu1PtMPdHFsRoom/emT4OtTcecmh3Zj22900y4Golg5whhBPcYcTPC7BU6PG/EmG9BBHcX9tQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-12.0.0.tgz",
+      "integrity": "sha512-MhbN76oRObM0bR/DyCsJnePm0QkmXhNFRZCCaPxLZtGyAnAP3r39scXfs2cROsM5ePemdbXH6aSowLKivluWtg==",
       "dev": true,
       "dependencies": {
-        "android-versions": "^1.7.0",
-        "cordova-common": "^4.0.2",
+        "android-versions": "^1.8.1",
+        "cordova-common": "^5.0.0",
         "execa": "^5.1.1",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^10.1.0",
+        "fast-glob": "^3.2.12",
+        "fs-extra": "^11.1.1",
         "is-path-inside": "^3.0.3",
-        "nopt": "^5.0.0",
+        "nopt": "^7.1.0",
         "properties-parser": "^0.3.1",
-        "semver": "^7.3.7",
+        "semver": "^7.3.8",
+        "string-argv": "^0.3.1",
         "untildify": "^4.0.0",
-        "which": "^2.0.2"
+        "which": "^3.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.13.0"
+      }
+    },
+    "node_modules/cordova-android/node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cordova-android/node_modules/bplist-parser": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
+    "node_modules/cordova-android/node_modules/cordova-common": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-5.0.0.tgz",
+      "integrity": "sha512-6Aa7o52/iEvsKx6K94ijzFel5acCULR49KL27OUVhEpJ4oS7Dc3y2eOP1Eu0P4Wmiw/eLEDQjGXGiAa2D5zFZA==",
+      "dev": true,
+      "dependencies": {
+        "@netflix/nerror": "^1.1.3",
+        "ansi": "^0.3.1",
+        "bplist-parser": "^0.3.2",
+        "cross-spawn": "^7.0.3",
+        "elementtree": "^0.1.7",
+        "endent": "^2.1.0",
+        "fast-glob": "^3.2.12",
+        "fs-extra": "^11.1.0",
+        "glob": "^7.1.6",
+        "lodash.assign": "^4.2.0",
+        "lodash.isdate": "^4.0.1",
+        "lodash.isobject": "^3.0.2",
+        "lodash.zip": "^4.2.0",
+        "plist": "^3.0.6",
+        "q": "^1.5.1",
+        "read-chunk": "^3.2.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/cordova-android/node_modules/endent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/endent/-/endent-2.1.0.tgz",
+      "integrity": "sha512-r8VyPX7XL8U01Xgnb1CjZ3XV+z90cXIJ9JPE/R9SEC9vpw2P6CfsRPJmp20DppC5N7ZAMCmjYkJIa744Iyg96w==",
+      "dev": true,
+      "dependencies": {
+        "dedent": "^0.7.0",
+        "fast-json-parse": "^1.0.3",
+        "objectorarray": "^1.0.5"
       }
     },
     "node_modules/cordova-android/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -220,22 +295,37 @@
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
-    "node_modules/cordova-android/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+    "node_modules/cordova-android/node_modules/nopt": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.0.tgz",
+      "integrity": "sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^6.0.0"
+        "abbrev": "^2.0.0"
       },
       "bin": {
-        "semver": "bin/semver.js"
+        "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cordova-android/node_modules/which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/cordova-clipboard": {
@@ -780,6 +870,30 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
+      "dev": true
+    },
+    "node_modules/lodash.isdate": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isdate/-/lodash.isdate-4.0.1.tgz",
+      "integrity": "sha512-hg5B1GD+R9egsBgMwmAhk+V53Us03TVvXT4dnyKugEfsD4QKuG9Wlyvxq8OGy2nu7qVGsh4DRSnMk33hoWBq/Q==",
+      "dev": true
+    },
+    "node_modules/lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+      "dev": true
+    },
+    "node_modules/lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
+      "dev": true
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -881,9 +995,9 @@
       }
     },
     "node_modules/objectorarray": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.4.tgz",
-      "integrity": "sha512-91k8bjcldstRz1bG6zJo8lWD7c6QXcB4nTDUqiEvIL1xAsLoZlOOZZG+nd6YPz+V7zY1580J4Xxh1vZtyv4i/w==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
+      "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
       "dev": true
     },
     "node_modules/once": {
@@ -968,17 +1082,17 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
       "dev": true,
       "dependencies": {
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10.4.0"
       }
     },
     "node_modules/properties-parser": {
@@ -1088,9 +1202,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1169,6 +1283,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string.prototype.codepointat": {
@@ -1348,22 +1471,12 @@
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true,
       "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1"
+        "node": ">=8.0"
       }
     },
     "node_modules/yallist": {
@@ -1411,6 +1524,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1418,20 +1537,12 @@
       "dev": true
     },
     "android-versions": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.8.1.tgz",
-      "integrity": "sha512-5a0YyylAk6pPM2Ezi0vWaPPNbS6tSNRs+micbgk5NpHEN5YW1ez+T94G5orysfwBEBDMHoxm5GNc5ZDUPgRrhw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.8.2.tgz",
+      "integrity": "sha512-2MT/Y/mR3BLSbR9E3ugwvE/aA4k84XtjG2Iusu4pRKt4FwfpEvIEAHzm7ZBhL3/aTVNdx3PzZ+sAiK+Dbc4r9A==",
       "dev": true,
       "requires": {
-        "semver": "^5.7.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "semver": "^7.5.2"
       }
     },
     "ansi": {
@@ -1459,9 +1570,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "big-integer": {
@@ -1514,28 +1625,80 @@
       "dev": true
     },
     "cordova-android": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-11.0.0.tgz",
-      "integrity": "sha512-ZhvSF5BYY8gmrAu1PtMPdHFsRoom/emT4OtTcecmh3Zj22900y4Golg5whhBPcYcTPC7BU6PG/EmG9BBHcX9tQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-12.0.0.tgz",
+      "integrity": "sha512-MhbN76oRObM0bR/DyCsJnePm0QkmXhNFRZCCaPxLZtGyAnAP3r39scXfs2cROsM5ePemdbXH6aSowLKivluWtg==",
       "dev": true,
       "requires": {
-        "android-versions": "^1.7.0",
-        "cordova-common": "^4.0.2",
+        "android-versions": "^1.8.1",
+        "cordova-common": "^5.0.0",
         "execa": "^5.1.1",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^10.1.0",
+        "fast-glob": "^3.2.12",
+        "fs-extra": "^11.1.1",
         "is-path-inside": "^3.0.3",
-        "nopt": "^5.0.0",
+        "nopt": "^7.1.0",
         "properties-parser": "^0.3.1",
-        "semver": "^7.3.7",
+        "semver": "^7.3.8",
+        "string-argv": "^0.3.1",
         "untildify": "^4.0.0",
-        "which": "^2.0.2"
+        "which": "^3.0.0"
       },
       "dependencies": {
+        "abbrev": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+          "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+          "dev": true
+        },
+        "bplist-parser": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+          "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+          "dev": true,
+          "requires": {
+            "big-integer": "1.6.x"
+          }
+        },
+        "cordova-common": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-5.0.0.tgz",
+          "integrity": "sha512-6Aa7o52/iEvsKx6K94ijzFel5acCULR49KL27OUVhEpJ4oS7Dc3y2eOP1Eu0P4Wmiw/eLEDQjGXGiAa2D5zFZA==",
+          "dev": true,
+          "requires": {
+            "@netflix/nerror": "^1.1.3",
+            "ansi": "^0.3.1",
+            "bplist-parser": "^0.3.2",
+            "cross-spawn": "^7.0.3",
+            "elementtree": "^0.1.7",
+            "endent": "^2.1.0",
+            "fast-glob": "^3.2.12",
+            "fs-extra": "^11.1.0",
+            "glob": "^7.1.6",
+            "lodash.assign": "^4.2.0",
+            "lodash.isdate": "^4.0.1",
+            "lodash.isobject": "^3.0.2",
+            "lodash.zip": "^4.2.0",
+            "plist": "^3.0.6",
+            "q": "^1.5.1",
+            "read-chunk": "^3.2.0",
+            "strip-bom": "^4.0.0"
+          }
+        },
+        "endent": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/endent/-/endent-2.1.0.tgz",
+          "integrity": "sha512-r8VyPX7XL8U01Xgnb1CjZ3XV+z90cXIJ9JPE/R9SEC9vpw2P6CfsRPJmp20DppC5N7ZAMCmjYkJIa744Iyg96w==",
+          "dev": true,
+          "requires": {
+            "dedent": "^0.7.0",
+            "fast-json-parse": "^1.0.3",
+            "objectorarray": "^1.0.5"
+          }
+        },
         "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -1543,13 +1706,22 @@
             "universalify": "^2.0.0"
           }
         },
-        "semver": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+        "nopt": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.0.tgz",
+          "integrity": "sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==",
           "dev": true,
           "requires": {
-            "lru-cache": "^6.0.0"
+            "abbrev": "^2.0.0"
+          }
+        },
+        "which": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+          "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -1864,7 +2036,7 @@
     "ionic-plugin-deeplinks": {
       "version": "git+ssh://git@github.com/vechain/ionic-plugin-deeplinks.git#603fca4c9fbcc6361ff9b3eb7a4b22ccba989c57",
       "dev": true,
-      "from": "ionic-plugin-deeplinks@git+https://github.com/vechain/ionic-plugin-deeplinks.git",
+      "from": "ionic-plugin-deeplinks@github:vechain/ionic-plugin-deeplinks",
       "requires": {
         "mkpath": ">=1.0.0",
         "node-version-compare": ">=1.0.1",
@@ -1956,6 +2128,30 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
+      "dev": true
+    },
+    "lodash.isdate": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isdate/-/lodash.isdate-4.0.1.tgz",
+      "integrity": "sha512-hg5B1GD+R9egsBgMwmAhk+V53Us03TVvXT4dnyKugEfsD4QKuG9Wlyvxq8OGy2nu7qVGsh4DRSnMk33hoWBq/Q==",
+      "dev": true
+    },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+      "dev": true
+    },
+    "lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
+      "dev": true
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2033,9 +2229,9 @@
       }
     },
     "objectorarray": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.4.tgz",
-      "integrity": "sha512-91k8bjcldstRz1bG6zJo8lWD7c6QXcB4nTDUqiEvIL1xAsLoZlOOZZG+nd6YPz+V7zY1580J4Xxh1vZtyv4i/w==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
+      "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
       "dev": true
     },
     "once": {
@@ -2093,14 +2289,14 @@
       "dev": true
     },
     "plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
       }
     },
     "properties-parser": {
@@ -2168,9 +2364,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -2228,6 +2424,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+      "dev": true
+    },
+    "string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
       "dev": true
     },
     "string.prototype.codepointat": {
@@ -2363,15 +2565,9 @@
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
-    },
-    "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true
     },
     "yallist": {

--- a/src-cordova/package.json
+++ b/src-cordova/package.json
@@ -13,7 +13,7 @@
   "author": "Apache Cordova Team",
   "license": "Apache-2.0",
   "devDependencies": {
-    "cordova-android": "^11.0.0",
+    "cordova-android": "^12.0.0",
     "cordova-clipboard": "^1.3.0",
     "cordova-ios": "^6.2.0",
     "cordova-plugin-add-swift-support": "^2.0.2",


### PR DESCRIPTION
Playstore requires the app must target Android 13 (API level 33) or higher, and cordova-android@12 meets this requirement. But it specifies node to be higher than 16 via `package.engines`, this will result in a warning during installation but not an error, so it still works for now(we are using node 14 as built env).