### PR TITLE
Add support for vet.domains

### DIFF
--- a/src/boot/services/blockchain/index.ts
+++ b/src/boot/services/blockchain/index.ts
@@ -1,6 +1,15 @@
 import { abis } from 'src/consts'
 import { createPool } from './pool'
 import { commitTx } from './tx-commiter'
+
+const VetDomainsResolverByGid: Record<string, string> = {
+    // MainNet Resolver Utility
+    '0x00000000851caf3cfdb6e899cf5958bfb1ac3413d346d43539627e6be7ec1b4a': '0xA11413086e163e41901bb81fdc5617c975Fa5a1A',
+
+    // TestNet Resolver Utility
+    '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127': '0xc403b8EA53F707d7d4de095f0A20bC491Cf2bc94'
+}
+
 function serve(gid: string, pool: ReturnType<typeof createPool>) {
     return {
         get thor() { return pool.get(gid).thor },
@@ -19,6 +28,64 @@ function serve(gid: string, pool: ReturnType<typeof createPool>) {
         },
         commitTx(raw: string) {
             commitTx(pool.resoleNode(gid).url, raw)
+        },
+        vetDomainsAddressesOf(names: string[]) {
+            if (!VetDomainsResolverByGid[gid]) { return [] }
+
+            const vetDomainsResolver = VetDomainsResolverByGid[gid]
+            return this.thor
+                .account(vetDomainsResolver)
+                .method({
+                    inputs: [
+                        {
+                            internalType: 'string[]',
+                            name: 'names',
+                            type: 'string[]'
+                        }
+                    ],
+                    name: 'getAddresses',
+                    outputs: [
+                        {
+                            internalType: 'address[]',
+                            name: 'addresses',
+                            type: 'address[]'
+                        }
+                    ],
+                    stateMutability: 'view',
+                    type: 'function'
+                })
+                .cache([])
+                .call(names)
+                .then(output => output.decoded.addresses)
+        },
+        vetDomainsNamesOf(addresses: string[]) {
+            if (!VetDomainsResolverByGid[gid]) { return [] }
+
+            const vetDomainsResolver = VetDomainsResolverByGid[gid]
+            return this.thor
+                .account(vetDomainsResolver)
+                .method({
+                    inputs: [
+                        {
+                            internalType: 'address[]',
+                            name: 'addresses',
+                            type: 'address[]'
+                        }
+                    ],
+                    name: 'getNames',
+                    outputs: [
+                        {
+                            internalType: 'string[]',
+                            name: 'names',
+                            type: 'string[]'
+                        }
+                    ],
+                    stateMutability: 'view',
+                    type: 'function'
+                })
+                .cache([])
+                .call(addresses)
+                .then(output => output.decoded.names)
         }
     }
 }

--- a/src/pages/Send/Controller.vue
+++ b/src/pages/Send/Controller.vue
@@ -13,6 +13,7 @@
             <To
                 v-model="to"
                 class="q-mx-md"
+                :gid="wallet && wallet.gid"
                 :wallets="toWallets"
                 :error-message="errors.to"
                 :error="!!errors.to"


### PR DESCRIPTION
This is a draft pull request to get an opinion on the implementation and guidance on how to proceed.

Goal of this PR is to get a first basic implementation of vet.domains name resolution. Names can be entered in the recipient field and it will use the associated address. If an address has a primary name, its name will be shown as hint with the address input.

Here is a demo to visualize the change:
![sync2](https://github.com/vechain/sync2/assets/407503/58eede0f-7ac0-4e80-9651-f5c6d7177f62)

Due some unfamiliarity with Vue, my questions are:

1. How can I best place the service for the name resolution with dependency to thor? I put it into the blockchain service but it feels like it should be its own service.
2. Is the integration generally okay in the way it was started?

If this is comes to a successful merge, I want to extend the integration with further display of names in another PR.